### PR TITLE
Remove usage of reserved async keyword

### DIFF
--- a/bellows/cli/ncp.py
+++ b/bellows/cli/ncp.py
@@ -9,7 +9,7 @@ from .main import main
 @click.argument('config', required=False)
 @click.option('-a', '--all', 'all_', is_flag=True)
 @click.pass_context
-@util.async
+@util.background
 async def config(ctx, config, all_):
     """Get/set configuration on the NCP"""
     click.secho(
@@ -69,7 +69,7 @@ async def config(ctx, config, all_):
 
 @main.command()
 @click.pass_context
-@util.async
+@util.background
 async def info(ctx):
     """Get NCP information"""
     s = await util.setup(ctx.obj['device'], ctx.obj['baudrate'])

--- a/bellows/cli/network.py
+++ b/bellows/cli/network.py
@@ -20,7 +20,7 @@ LOGGER = logging.getLogger(__name__)
 @opts.extended_pan
 @opts.pan
 @click.pass_context
-@util.async
+@util.background
 async def join(ctx, channels, pan_id, extended_pan_id):
     """Join an existing ZigBee network as an end device"""
     def cb(fut, frame_name, response):
@@ -111,7 +111,7 @@ async def join(ctx, channels, pan_id, extended_pan_id):
 
 @main.command()
 @click.pass_context
-@util.async
+@util.background
 async def leave(ctx):
     """Leave the ZigBee network"""
     s = await util.setup(ctx.obj['device'], ctx.obj['baudrate'])
@@ -130,7 +130,7 @@ async def leave(ctx):
 @opts.duration_ms
 @click.option('-e', '--energy', 'energy_scan', is_flag=True)
 @click.pass_context
-@util.async
+@util.background
 async def scan(ctx, channels, duration_ms, energy_scan):
     """Scan for networks or radio interference"""
     s = await util.setup(ctx.obj['device'], ctx.obj['baudrate'])

--- a/bellows/cli/util.py
+++ b/bellows/cli/util.py
@@ -33,7 +33,7 @@ class ZigbeeNodeParamType(click.ParamType):
         return t.EmberEUI64([t.uint8_t(p, base=16) for p in value.split(':')])
 
 
-def async(f):
+def background(f):
     @functools.wraps(f)
     def inner(*args, **kwargs):
         loop = asyncio.get_event_loop()

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py35, py36, lint
+envlist = py35, py36, py37, lint
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Cherry-pick b34d1f95 from zigpy/bellows

This makes bellows compatible with recent python versions (3.7)